### PR TITLE
feat(overlay): add backdrop tap frontlight control

### DIFF
--- a/screenlockpin.koplugin/plugin/ui/lockscreen/lockscreenframe.lua
+++ b/screenlockpin.koplugin/plugin/ui/lockscreen/lockscreenframe.lua
@@ -78,6 +78,8 @@ local LockScreenFrame = InputContainer:extend(WidgetContainer:extend {
 
     _refresh_region = nil,
     _content_region = nil,
+    outside_input = nil,
+    panel = nil,
 })
 
 function LockScreenFrame:init()
@@ -125,6 +127,7 @@ function LockScreenFrame:init()
             self.action_row,
         }
     }
+    self[2] = self.panel
 end
 
 function LockScreenFrame:setVisible(bool)


### PR DESCRIPTION
Fixes #11

This PR adds simple frontlight controls to the lock screen. If you press anywhere above the center and outside the keypad, the brightness goes up. If you press anywhere below the center and outside the keypad, the brightness goes down.

Thanks,
Hady